### PR TITLE
[Properties] Add spring-configuration-metadata.json with description of properties provided by library

### DIFF
--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,24 @@
+{
+  "properties": [
+    {
+      "name": "bot.name",
+      "type": "java.lang.String",
+      "description": "Telegram bot username."
+    },
+    {
+      "name": "bot.token",
+      "type": "java.lang.String",
+      "description": "Telegram bot token."
+    },
+    {
+      "name": "bot.uri",
+      "type": "java.lang.String",
+      "description": "URI to send a request to your application. Required only if you are creating telegram bot with webhook."
+    },
+    {
+      "name": "bot.base_url",
+      "type": "java.lang.String",
+      "description": "URL to send a request to your Local Bot API Server (by default https://api.telegram.org/bot). Required only if you are creating telegram bot with Local Bot API Server."
+    }
+  ]
+}


### PR DESCRIPTION
Spring allows to describe properties which could be used by library users. It improves understanding of what specific property is used for and gets rid of IDEA warning.

---
Idk your CI/CD processes so I just left version unchanged for now. Pls let me know if I need to take further actions. 